### PR TITLE
Add Domains to Oxford University Press

### DIFF
--- a/oup/manifest.json
+++ b/oup/manifest.json
@@ -20,7 +20,9 @@
     "www.oxfordhandbooks.com",
     "public.oed.com",
     "www.oed.com",
-    "annualreport.oup.com"
+    "annualreport.oup.com",
+    "www.oxfordartonline.com",
+    "www.oxfordscholarship.com"
 	],
   "bacon": {
     "provider": "OUP"


### PR DESCRIPTION
### What are you adding/fixing?
Adds domains for www.oxfordartonline.com and www.oxfordscholarship.com to the manifest for Oxford University Press.

#### Awesome List for Reviewers of Parsers :star::star:
- [x] fetch new branch to local repo 'git pull'
- [x] checkout new branch to test 'git checkout --track origin/{nameofbranch}' / make sure you're on correct branch with 'git status'
- [x] find proxied resource and look through it (this generates entries in the logs).  Try to go through everything in nav bar since this will likely have most of the domain changes.
- [x] go to the logs on the main proxy server and grep for your username.  Use these lines to then test.
- [x] check output from parser directory:  'echo 'line from log' | ./parser.js
- [x] check manifest.json to make sure no information is missing
- [x] review/approve/merge pull request based on findings

