### PR TITLE
Adds Parser for Elsevier Journals

### DIFF
--- a/elsevier/manifest.json
+++ b/elsevier/manifest.json
@@ -1,0 +1,14 @@
+{
+  "longname": "Elsevier Journals",
+  "name": "elsevier",
+  "describe": "Recognizes the accesses to the platform Elsevier Journals",
+  "contact": "acoope5@emory.edu",
+  "pkb": false,
+  "docurl": "http://ang.couperin.org/platforms/to_be_completed/",
+  "domains": [
+    "www.journals.elsevier.com",
+    "journals.elsevier.com"
+  ],
+  "version": "2019-07-09",
+  "status": "beta"
+}

--- a/elsevier/parser.js
+++ b/elsevier/parser.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+'use strict';
+const Parser = require('../.lib/parser.js');
+
+/**
+ * Recognizes the accesses to the platform Elsevier Journals
+ * @param  {Object} parsedUrl an object representing the URL to analyze
+ *                            main attributes: pathname, query, hostname
+ * @param  {Object} ec        an object representing the EC whose URL is being analyzed
+ * @return {Object} the result
+ */
+module.exports = new Parser(function analyseEC(parsedUrl, ec) {
+  let result = {};
+  let path   = parsedUrl.pathname;
+  // let param = parsedUrl.query || {};
+  // console.error(parsedUrl);
+
+  let match;
+
+  if ((match = /^\/([a-zA-Z0-9-]+)$/i.exec(path)) !== null) {
+    // https://www.journals.elsevier.com:443/journal-of-reproductive-immunology
+    result.publication_title = match[1];
+    result.unitid            = match[1];
+    result.rtype             = 'REF';
+    result.mime              = 'HTML';
+
+  } else if ((match = /^\/([a-zA-Z0-9-]+)\/([a-zA-Z0-9-]+)$/i.exec(path)) !== null) {
+    // https://www.journals.elsevier.com:443/journal-of-reproductive-immunology/editorial-board
+    // https://www.journals.elsevier.com:443/contemporary-clinical-trials-communications/recent-articles
+    result.publication_title = match[1];
+    result.unitid            = match[2];
+    result.mime              = 'HTML';
+    if (match[2] == 'editorial-board') {
+      result.rtype           = 'REF';
+    }
+    if (match[2] !== 'editorial-board') {
+      result.rtype           = 'TOC';
+    }
+
+  } else if ((match = /^\/([a-zA-Z0-9-]+)\/([a-zA-Z0-9-]+)\/([a-zA-Z0-9-]+)$/i.exec(path)) !== null) {
+    // https://www.journals.elsevier.com:443/journal-of-reproductive-immunology/editorial-board/prof-petra-arck
+    // https://www.journals.elsevier.com:443/current-opinion-in-toxicology/news/new-series-of-open-access-titles
+    result.publication_title = match[1];
+    result.unitid            = match[3];
+    result.mime              = 'HTML';
+    if (match[2] == 'editorial-board') {
+      result.rtype           = 'BIO';
+    }
+    if (match[2] !== 'editorial-board') {
+      result.rtype           = 'ARTICLE';
+    }
+  }
+
+  return result;
+});

--- a/elsevier/test/elsevier.2019-07-09.csv
+++ b/elsevier/test/elsevier.2019-07-09.csv
@@ -1,0 +1,12 @@
+out-publication_title;out-unitid;out-rtype;out-mime;in-url
+ibro-reports;ibro-reports;REF;HTML;https://www.journals.elsevier.com:443/ibro-reports
+journal-of-reproductive-immunology;journal-of-reproductive-immunology;REF;HTML;https://www.journals.elsevier.com:443/journal-of-reproductive-immunology
+journal-of-reproductive-immunology;editorial-board;REF;HTML;https://www.journals.elsevier.com:443/journal-of-reproductive-immunology/editorial-board
+journal-of-reproductive-immunology;prof-petra-arck;BIO;HTML;https://www.journals.elsevier.com:443/journal-of-reproductive-immunology/editorial-board/prof-petra-arck
+current-opinion-in-toxicology;current-opinion-in-toxicology;REF;HTML;https://www.journals.elsevier.com:443/current-opinion-in-toxicology
+current-opinion-in-toxicology;news;TOC;HTML;https://www.journals.elsevier.com:443/current-opinion-in-toxicology/news
+current-opinion-in-toxicology;new-series-of-open-access-titles;ARTICLE;HTML;https://www.journals.elsevier.com:443/current-opinion-in-toxicology/news/new-series-of-open-access-titles
+contemporary-clinical-trials-communications;contemporary-clinical-trials-communications;REF;HTML;https://www.journals.elsevier.com:443/contemporary-clinical-trials-communications
+contemporary-clinical-trials-communications;most-downloaded-articles;TOC;HTML;https://www.journals.elsevier.com:443/contemporary-clinical-trials-communications/most-downloaded-articles
+contemporary-clinical-trials-communications;recent-articles;TOC;HTML;https://www.journals.elsevier.com:443/contemporary-clinical-trials-communications/recent-articles
+contemporary-clinical-trials-communications;most-cited-articles;TOC;HTML;https://www.journals.elsevier.com:443/contemporary-clinical-trials-communications/most-cited-articles


### PR DESCRIPTION
### What are you adding/fixing?
Adds parser for journals.elsevier.com only.
Elsevier articles are on Science Direct and the Elsevier journals not on Science Direct are on their own domains, but there is some information about the journal here that occasionally shows up in the logs.

VERY IMPORTANT: YOU CANNOT PROXY ELSEVIER.COM BECAUSE IT BREAKS OTHER PARSERS! THIS PARSER IS ONLY FOR JOURNALS.ELSEVIER.COM!

#### Awesome List for Reviewers of Parsers :star::star:
- [x] fetch new branch to local repo 'git pull'
- [x] checkout new branch to test 'git checkout --track origin/{nameofbranch}' / make sure you're on correct branch with 'git status'
- [x] find proxied resource and look through it (this generates entries in the logs).  Try to go through everything in nav bar since this will likely have most of the domain changes.
- [x] go to the logs on the main proxy server and grep for your username.  Use these lines to then test.
- [x] check output from parser directory:  'echo 'line from log' | ./parser.js
- [x] check manifest.json to make sure no information is missing
- [x] review/approve/merge pull request based on findings