### PR TITLE
Splits Articles and eBooks for JSTOR

### DIFF
--- a/jstor/parser.js
+++ b/jstor/parser.js
@@ -83,9 +83,17 @@ module.exports = new Parser(function analyseEC(parsedUrl) {
       result.rtype = 'ARTICLE_SECTION';
       result.mime  = 'GIF';
       break;
-    case 'pdf':
-      result.rtype = 'ARTICLE';
-      result.mime  = 'PDF';
+    case ('pdf'):
+      switch (match[2]) {
+      case (match[2].match(/^j.ctt*/) || {}).input:
+        result.rtype = 'BOOK_SECTION';
+        result.mime  = 'PDF';
+        break;
+      default:
+        result.rtype = 'ARTICLE';
+        result.mime  = 'PDF';
+        break;
+      }
       break;
     case 'pdfplus':
       result.rtype = 'ARTICLE';


### PR DESCRIPTION
### What are you adding/fixing?
Splitting pdfs to show ebooks vs articles.

#### Awesome List for Reviewers of Parsers :star::star:
- [x] fetch new branch to local repo 'git pull'
- [x] checkout new branch to test 'git checkout --track origin/{nameofbranch}' / make sure you're on correct branch with 'git status'
- [x] find proxied resource and look through it (this generates entries in the logs).  Try to go through everything in nav bar since this will likely have most of the domain changes.
- [x] go to the logs on the main proxy server and grep for your username.  Use these lines to then test.
- [ ] check output from parser directory:  'echo 'line from log' | ./parser.js
- [ ] check manifest.json to make sure no information is missing
- [ ] review/approve/merge pull request based on findings